### PR TITLE
fix: fix peer dependency for minor fixes in strapi packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "kind": "plugin"
   },
   "peerDependencies": {
-    "@strapi/strapi": "4.1.9"
+    "@strapi/strapi": "^4.1"
   },
   "dependencies": {
     "google-auth-library": "^8.0.2",


### PR DESCRIPTION
fix peer dependency for minor fixes in strapi packages using `"^4.1"`   instead ` "4.1.9"`   because can't install this package on latest version of strapi